### PR TITLE
Default Ajax request to backend into the callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ Angular.JS wrapper for Google's No CAPTCHA reCAPTCHA. See demo at [http://codedi
     var app = angular.module('myApp', ['noCAPTCHA']);
     ```
 
-1. (IMPORTANT) Set the callback request method/endpoint
-	You must set the request method,endpoint,headers to your backend page for user's response verification.
+1. (IMPORTANT) Set the request method,endpoint,headers to your backend page for user's response verification.
 	(See [https://developers.google.com/recaptcha/docs/verify](there) for details).
 	The result of verification (true or false) will be bind into g-recaptcha-success expression.
     ```javascript

--- a/README.md
+++ b/README.md
@@ -26,31 +26,55 @@ Angular.JS wrapper for Google's No CAPTCHA reCAPTCHA. See demo at [http://codedi
     var app = angular.module('myApp', ['noCAPTCHA']);
     ```
 
+1. (IMPORTANT) Set the callback request method/endpoint
+	You must set the request method,endpoint,headers to your backend page for user's response verification.
+	(See [https://developers.google.com/recaptcha/docs/verify](there) for details).
+	The result of verification (true or false) will be bind into g-recaptcha-success expression.
+    ```javascript
+    angular.module('myApp')
+      .config(['noCAPTCHAProvider', function (noCaptchaProvider) {
+	  	noCaptchaProvider.setReq({
+			method: 'POST',
+			url: '/recaptcha'
+		});
+      }
+    ]);
+    ```
+
 1. (Optional step) Set default options for noCAPTCHA 
     ```javascript
     angular.module('myApp')
       .config(['noCAPTCHAProvider', function (noCaptchaProvider) {
+	  	noCaptchaProvider.setReq({
+			method: 'POST',
+			url: '/recaptcha'
+		});
         noCaptchaProvider.setSiteKey('<your site key>');
         noCaptchaProvider.setTheme('dark');
       }
     ]);
     ```
     
-1. Finally add noCaptcha element to your form
+1. Add noCaptcha element to your form
     ```html
     <no-captcha
-        g-recaptcha-response="gRecaptchaResponse"
+        g-recaptcha-success="verificated"
         theme='light'
         control="noCaptchaControl"
         site-key="<your site key>">
     </no-captcha>
     ```
+	
+1. Enable/disable submit button according to the g-recaptcha-success state
+	```html
+	<button ng-disable="!verificated">Submit</button>
+	```
 
 ## no-captcha element parameters
 
 | Param                | Type                   | Details                                                            |
 |----------------------|------------------------|--------------------------------------------------------------------|
-| g-recaptcha-response | Expression             | Bind reCAPTCHA response token                                      |
+| g-recaptcha-success | Expression             | Bind reCAPTCHA verification response                                      |
 | theme                | String {light \| dark} | Optional. The color theme of the widget. Can be set also in config |
 | site-key             | String                 | Optional. Your site key. Can be set also in config                 |
 | control              | Expression             | Optional. Object where reset-function will be injected             |

--- a/src/angular-no-captcha.js
+++ b/src/angular-no-captcha.js
@@ -1,94 +1,96 @@
 'use strict';
 
 angular.module('noCAPTCHA', [])
-	.service('googleGrecaptcha', ['$q', '$window', function GoogleGrecaptchaService($q, $window) {
-		var deferred = $q.defer();
+  .service('googleGrecaptcha', ['$q', '$window', function GoogleGrecaptchaService($q, $window) {
+    var deferred = $q.defer();
 
-		$window.recaptchaOnloadCallback = function() {
-			deferred.resolve();
-		};
+    $window.recaptchaOnloadCallback = function() {
+      deferred.resolve();
+    };
 
-		var s = document.createElement('script');
-		s.src = 'https://www.google.com/recaptcha/api.js?onload=recaptchaOnloadCallback&render=explicit';
-		document.body.appendChild(s);
+    var s = document.createElement('script');
+    s.src = 'https://www.google.com/recaptcha/api.js?onload=recaptchaOnloadCallback&render=explicit';
+    document.body.appendChild(s);
 
-		return deferred.promise;
-	}])
-	.provider('noCAPTCHA', function NoCaptchaProvider() {
-		var siteKey,
-			theme,
-			req;
+    return deferred.promise;
+  }])
+  .provider('noCAPTCHA', function NoCaptchaProvider() {
+    var siteKey,
+      theme,
+      req;
 
-		this.setSiteKey = function(_siteKey) {
-			siteKey = _siteKey;
-		};
+    this.setSiteKey = function(_siteKey) {
+      siteKey = _siteKey;
+    };
 
-		this.setTheme = function(_theme) {
-			theme = _theme;
-		};
+    this.setTheme = function(_theme) {
+      theme = _theme;
+    };
 
-		this.setReq = function(_req) {
-			req = _req;
-		};
+    this.setReq = function(_req) {
+      req = _req;
+    };
 
-		this.$get = [function NoCaptchaFactory() {
-			return {
-				theme: theme,
-				siteKey: siteKey,
-				req: req
-			}
-		}];
-	})
-	.directive('noCaptcha', ['noCAPTCHA', 'googleGrecaptcha', '$http', function(noCaptcha, googleGrecaptcha, $http) {
-		return {
-			restrict: 'EA',
-			scope: {
-				gRecaptchaSuccess: '=',
-				siteKey: '@',
-				theme: '@',
-				control: '='
-			},
-			replace: true,
-			link: function(scope, element) {
-				var widgetId,
-					grecaptchaCreateParameters,
-					control = scope.control || {};
+    this.$get = [function NoCaptchaFactory() {
+      return {
+        theme: theme,
+        siteKey: siteKey,
+        req: req
+      }
+    }];
+  })
+  .directive('noCaptcha', ['noCAPTCHA', 'googleGrecaptcha', '$http', function(noCaptcha, googleGrecaptcha, $http) {
+    return {
+      restrict: 'EA',
+      scope: {
+        gRecaptchaSuccess: '=',
+        siteKey: '@',
+        theme: '@',
+        control: '='
+      },
+      replace: true,
+      link: function(scope, element) {
+        var widgetId,
+          grecaptchaCreateParameters,
+          control = scope.control || {};
 
-				grecaptchaCreateParameters = {
-					sitekey: scope.siteKey || noCaptcha.siteKey,
-					theme: scope.theme || noCaptcha.theme,
-					callback: function(response) {
-						noCaptcha.req.data = {responseString: response};
-						
-						$http(noCaptcha.req).
-						success(function(data, status, headers, config) {
-							scope.gRecaptchaSuccess = data.success;
-						}).
-						error(function(data, status, headers, config) {
-							scope.gRecaptchaSuccess = false;
-							console.log(data);
-						})
-					}
-				};
+        grecaptchaCreateParameters = {
+          sitekey: scope.siteKey || noCaptcha.siteKey,
+          theme: scope.theme || noCaptcha.theme,
+          callback: function(response) {
+            noCaptcha.req.data = {
+              responseString: response
+            };
 
-				if (!grecaptchaCreateParameters.sitekey) {
-					throw new Error('Site Key is required');
-				}
+            $http(noCaptcha.req).
+            success(function(data, status, headers, config) {
+              scope.gRecaptchaSuccess = data.success;
+            }).
+            error(function(data, status, headers, config) {
+              scope.gRecaptchaSuccess = false;
+              console.log(data);
+            })
+          }
+        };
 
-				googleGrecaptcha.then(function() {
-					widgetId = grecaptcha.render(
-						element[0],
-						grecaptchaCreateParameters
-					);
-					control.reset = function() {
-						grecaptcha.reset(widgetId);
-						scope.gRecaptchaSuccess = false;
-					};
-				});
+        if (!grecaptchaCreateParameters.sitekey) {
+          throw new Error('Site Key is required');
+        }
 
-				scope.$on('$destroy', function() {
-					grecaptcha.reset(widgetId);
-				});
-			}
-		};
-	}]);
+        googleGrecaptcha.then(function() {
+          widgetId = grecaptcha.render(
+            element[0],
+            grecaptchaCreateParameters
+          );
+          control.reset = function() {
+            grecaptcha.reset(widgetId);
+            scope.gRecaptchaSuccess = false;
+          };
+        });
+
+        scope.$on('$destroy', function() {
+          grecaptcha.reset(widgetId);
+        });
+      }
+    };
+  }]);

--- a/src/angular-no-captcha.js
+++ b/src/angular-no-captcha.js
@@ -1,81 +1,94 @@
 'use strict';
 
 angular.module('noCAPTCHA', [])
-  .service('googleGrecaptcha', ['$q', '$window', function GoogleGrecaptchaService($q, $window) {
-    var deferred = $q.defer();
+	.service('googleGrecaptcha', ['$q', '$window', function GoogleGrecaptchaService($q, $window) {
+		var deferred = $q.defer();
 
-    $window.recaptchaOnloadCallback = function () {
-      deferred.resolve();
-    };
+		$window.recaptchaOnloadCallback = function() {
+			deferred.resolve();
+		};
 
-    var s = document.createElement('script');
-    s.src = 'https://www.google.com/recaptcha/api.js?onload=recaptchaOnloadCallback&render=explicit';
-    document.body.appendChild(s);
+		var s = document.createElement('script');
+		s.src = 'https://www.google.com/recaptcha/api.js?onload=recaptchaOnloadCallback&render=explicit';
+		document.body.appendChild(s);
 
-    return deferred.promise;
-  }])
-  .provider('noCAPTCHA', function NoCaptchaProvider() {
-    var siteKey,
-      theme;
+		return deferred.promise;
+	}])
+	.provider('noCAPTCHA', function NoCaptchaProvider() {
+		var siteKey,
+			theme,
+			req;
 
-    this.setSiteKey = function(_siteKey){
-      siteKey = _siteKey;
-    };
+		this.setSiteKey = function(_siteKey) {
+			siteKey = _siteKey;
+		};
 
-    this.setTheme = function(_theme){
-      theme = _theme;
-    };
+		this.setTheme = function(_theme) {
+			theme = _theme;
+		};
 
-    this.$get = [function NoCaptchaFactory() {
-      return {
-        theme: theme,
-        siteKey: siteKey
-      }
-    }];
-  })
-  .directive('noCaptcha', ['noCAPTCHA','googleGrecaptcha', function(noCaptcha, googleGrecaptcha){
-    return {
-      restrict:'EA',
-      scope: {
-        gRecaptchaResponse:'=',
-        siteKey:'@',
-        theme:'@',
-        control:'='
-      },
-      replace: true,
-      link: function(scope, element) {
-        var widgetId,
-          grecaptchaCreateParameters,
-          control = scope.control || {};
+		this.setReq = function(_req) {
+			req = _req;
+		};
 
-        grecaptchaCreateParameters = {
-          sitekey: scope.siteKey || noCaptcha.siteKey,
-          theme: scope.theme || noCaptcha.theme,
-          callback: function(r){
-            scope.$apply(function(){
-              scope.gRecaptchaResponse = r;
-            });
-          }
-        };
+		this.$get = [function NoCaptchaFactory() {
+			return {
+				theme: theme,
+				siteKey: siteKey,
+				req: req
+			}
+		}];
+	})
+	.directive('noCaptcha', ['noCAPTCHA', 'googleGrecaptcha', '$http', function(noCaptcha, googleGrecaptcha, $http) {
+		return {
+			restrict: 'EA',
+			scope: {
+				gRecaptchaSuccess: '=',
+				siteKey: '@',
+				theme: '@',
+				control: '='
+			},
+			replace: true,
+			link: function(scope, element) {
+				var widgetId,
+					grecaptchaCreateParameters,
+					control = scope.control || {};
 
-        if(!grecaptchaCreateParameters.sitekey){
-          throw new Error('Site Key is required');
-        }
+				grecaptchaCreateParameters = {
+					sitekey: scope.siteKey || noCaptcha.siteKey,
+					theme: scope.theme || noCaptcha.theme,
+					callback: function(response) {
+						noCaptcha.req.data = {responseString: response};
+						
+						$http(noCaptcha.req).
+						success(function(data, status, headers, config) {
+							scope.gRecaptchaSuccess = data.success;
+						}).
+						error(function(data, status, headers, config) {
+							scope.gRecaptchaSuccess = false;
+							console.log(data);
+						})
+					}
+				};
 
-        googleGrecaptcha.then(function(){
-          widgetId = grecaptcha.render(
-            element[0],
-            grecaptchaCreateParameters
-          );
-          control.reset = function(){
-            grecaptcha.reset(widgetId);
-            scope.gRecaptchaResponse = null;
-          };
-        });
+				if (!grecaptchaCreateParameters.sitekey) {
+					throw new Error('Site Key is required');
+				}
 
-        scope.$on('$destroy', function(){
-          grecaptcha.reset(widgetId);
-        });
-      }
-    };
-  }]);
+				googleGrecaptcha.then(function() {
+					widgetId = grecaptcha.render(
+						element[0],
+						grecaptchaCreateParameters
+					);
+					control.reset = function() {
+						grecaptcha.reset(widgetId);
+						scope.gRecaptchaSuccess = false;
+					};
+				});
+
+				scope.$on('$destroy', function() {
+					grecaptcha.reset(widgetId);
+				});
+			}
+		};
+	}]);


### PR DESCRIPTION
It could be useful to create a default http ajax request the to backend for user's response verification.
So you can use the angular-no-captcha module more like a service, binding directly the verification response to disable/enable submit button (ie.)