### PR TITLE
Added reset option

### DIFF
--- a/src/angular-no-captcha.js
+++ b/src/angular-no-captcha.js
@@ -41,7 +41,8 @@ angular.module('noCAPTCHA', [])
         siteKey:'@',
         theme:'@',
         control:'=',
-        expiredCallback: '='
+        expiredCallback: '=',
+        reset: '='
       },
       replace: true,
       link: function(scope, element) {
@@ -64,6 +65,10 @@ angular.module('noCAPTCHA', [])
               });
             }
           }
+        };
+
+        scope.reset = function () {
+          grecaptcha.reset(widgetId);
         };
 
         if(!grecaptchaCreateParameters.sitekey){


### PR DESCRIPTION
I added the ability to reset the captcha manually. This is helpful if the form was submitted correctly, and captcha was validated (making the response now invalid) but the form was invalid, requiring a re-response of the form to the server. Since the captcha response cannot be resubmitted, a reset of the form is required.