### PR TITLE
Adjust scope.control to allow for non-defined object

### DIFF
--- a/src/angular-no-captcha.js
+++ b/src/angular-no-captcha.js
@@ -45,9 +45,11 @@ angular.module('noCAPTCHA', [])
       },
       replace: true,
       link: function(scope, element) {
+        scope.control = scope.control || {};
+        
         var widgetId,
           grecaptchaCreateParameters,
-          control = scope.control || {};
+          control = scope.control;
 
         grecaptchaCreateParameters = {
           sitekey: scope.siteKey || noCaptcha.siteKey,


### PR DESCRIPTION
Currently, in order to have reset injected into your control object, you must do the following:

```
HTML
<no-captcha control="control"></no-captcha>

CONTROLLER
$scope.control = {};

*elsewhere*.
$scope.reset();
```

This allows for you to do the following:

```
HTML
<no-captcha control="control"></no-captcha>

CONTROLLER
$scope.reset();
```

Essentially, it makes priming the control as an object optional.