### PR TITLE
Ensure grecaptcha reset exists

### DIFF
--- a/src/angular-no-captcha.js
+++ b/src/angular-no-captcha.js
@@ -118,7 +118,9 @@ angular
           });
 
           scope.$on('$destroy', function (){
-            grecaptcha.reset(widgetId);
+            if(grecaptcha) {
+              grecaptcha.reset(widgetId);
+            }
             removePLSContainers();
           });
         }

--- a/src/angular-no-captcha.js
+++ b/src/angular-no-captcha.js
@@ -45,7 +45,8 @@ angular
     'noCAPTCHA',
     'googleGrecaptcha',
     '$document',
-    function (noCaptcha, googleGrecaptcha, $document){
+    '$window',
+    function (noCaptcha, googleGrecaptcha, $document, $window){
       /**
        * Removes all .pls-container elements
        *
@@ -107,19 +108,19 @@ angular
           }
 
           googleGrecaptcha.then(function (){
-            widgetId = grecaptcha.render(
+            widgetId = $window.grecaptcha.render(
               element[0],
               grecaptchaCreateParameters
             );
             control.reset = function (){
-              grecaptcha.reset(widgetId);
+              $window.grecaptcha.reset(widgetId);
               scope.gRecaptchaResponse = null;
             };
           });
 
           scope.$on('$destroy', function (){
-            if(grecaptcha) {
-              grecaptcha.reset(widgetId);
+            if($window.grecaptcha) {
+              $window.grecaptcha.reset(widgetId);
             }
             removePLSContainers();
           });


### PR DESCRIPTION
Error will be thrown if destroy hook gets called before `grecaptcha` is initialized.

This pr fixes the issue by checking if the `grecaptcha` exists.