### PR TITLE
Added support for stoken

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Angular.JS wrapper for Google's No CAPTCHA reCAPTCHA. See demo at [http://codedi
 | theme                | String {light \| dark}     | Optional. The color theme of the widget. Can be set also in config                                                                                    |
 | size                 | String {normal \| compact} | Optional. The size of the widget. Can be set also in config                                                                                           |
 | site-key             | String                     | Optional. Your site key. Can be set also in config                                                                                                    |
+| stoken               | String                     | Optional. Your [secure token](https://developers.google.com/recaptcha/docs/secure_token). Can **only** be set in your element.                        |
 | language             | String                     | Optional. Forces the widget to render in a specific [language](https://developers.google.com/recaptcha/docs/language). Can **only** be set in config. |
 | control              | Expression                 | Optional. Object where reset-function will be injected                                                                                                |
 | expired-callback     | Expression                 | Optional. Callback for expired event                                                                                                                  |

--- a/src/angular-no-captcha.js
+++ b/src/angular-no-captcha.js
@@ -100,6 +100,7 @@ angular
         scope: {
           gRecaptchaResponse: '=',
           siteKey: '@',
+          stoken: '@',
           size: '@',
           theme: '@',
           control: '=?',
@@ -130,6 +131,10 @@ angular
               }
             }
           };
+
+          if (scope.stoken) {
+            grecaptchaCreateParameters.stoken = scope.stoken;
+          }
 
           if(!grecaptchaCreateParameters.sitekey) {
             throw new Error('Site Key is required');


### PR DESCRIPTION
This adds support for stoken as described on this page:

https://developers.google.com/recaptcha/docs/secure_token

I did not include anything in the noCaptchaProvider section for setting default options. This token includes a timestamp, so it seems more appropriate to set it when creating the recaptcha instance as opposed to in a global configuration.